### PR TITLE
Configure TMC workspaces for notional workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,18 @@ steps:
    certificate (it's easier that way). 
 
    ```
-   ytt -f config/letsencrypt --data-value email=$EMAIL | kubectl -f - i
+   ytt -f config/letsencrypt --data-value email=$EMAIL | kubectl apply -f -
    ```
 
-6. Create a secrets file `secrets/harbor.yml` using the following template:
+6. Set up TMC workspaces for governing namespaces used for tool, development, staging, and production workloads.
+   ```
+   tmc workspace create -f config/workspaces/tools.yaml
+   tmc workspace create -f config/workspaces/development.yaml
+   tmc workspace create -f config/workspaces/staging.yaml
+   tmc workspace create -f config/workspaces/production.yaml
+   ```
+
+7. Create a secrets file `secrets/harbor.yml` using the following template:
 
    ```
    harborAdminPassword:
@@ -58,13 +66,14 @@ steps:
      password:
    ``` 
 
-7. Install Harbor with Helm 
+8. Install Harbor with Helm 
 
    ```
    ytt -f config/harbor -f values/harbor.yml --data-value subdomain=$SUBDOMAIN --ignore-unknown-comments > work/harbor.yml 
    kubectl create namespace registry
    helm install -n registry feasible-macaque bitnami/harbor -f secrets/harbor.yml -f work/harbor.yml
    ```
+
 ## Assumptions
 
 1. You want to use a Let's Encrypt certificate.

--- a/config/workspaces/development.yaml
+++ b/config/workspaces/development.yaml
@@ -1,0 +1,11 @@
+fullName:
+  name: crdant-development
+objectMeta:
+  annotations: null
+  description: ""
+  labels: null
+typeMeta:
+  kind: Workspace
+  package: vmware.olympus.v1alpha.workspace
+  version: v1alpha
+

--- a/config/workspaces/production.yaml
+++ b/config/workspaces/production.yaml
@@ -1,0 +1,11 @@
+fullName:
+  name: crdant-production
+objectMeta:
+  annotations: null
+  description: ""
+  labels: null
+typeMeta:
+  kind: Workspace
+  package: vmware.olympus.v1alpha.workspace
+  version: v1alpha
+

--- a/config/workspaces/staging.yaml
+++ b/config/workspaces/staging.yaml
@@ -1,0 +1,11 @@
+fullName:
+  name: crdant-staging
+objectMeta:
+  annotations: null
+  description: ""
+  labels: null
+typeMeta:
+  kind: Workspace
+  package: vmware.olympus.v1alpha.workspace
+  version: v1alpha
+

--- a/config/workspaces/tools.yaml
+++ b/config/workspaces/tools.yaml
@@ -1,0 +1,11 @@
+fullName:
+  name: crdant-tools
+objectMeta:
+  annotations: null
+  description: ""
+  labels: null
+typeMeta:
+  kind: Workspace
+  package: vmware.olympus.v1alpha.workspace
+  version: v1alpha
+


### PR DESCRIPTION
TL;DR
-----

Adds configuration for TMC workspaces and instructions to create
them.

Details
-------

The demonstration focuses on using the TMC workspace concept to
vary the image governance policies. We show a notional structure
where workloads are divided into four categories:

1. _Tools_. Tooling that supports development and operations of
   the environment. At this point, the tooling is just the Harbor
   registry.
2. _Development_. Represents a fairly loosely governed environment
   for development and experimentation.
3. _Staging_. Tightens controls to create an environment for
   testing and validation.
4. _Production_. The tightest level of control representing live
   mission critical workloads.