### PR TITLE
Include contour as an ingress controller

### DIFF
--- a/config/contour/psp.yml
+++ b/config/contour/psp.yml
@@ -1,0 +1,50 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: contour-envoy
+spec:
+  hostPorts:
+  - min: 80
+    max: 80
+  - min: 443
+    max: 443
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - emptyDir
+  - secret
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: contour-envoy
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - contour-envoy
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: contour-envoy
+  namespace: projectcontour
+roleRef:
+  kind: ClusterRole
+  name: contour-envoy
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: envoy
+  namespace: projectcontour

--- a/config/namespaces/namespace.yaml
+++ b/config/namespaces/namespace.yaml
@@ -1,0 +1,18 @@
+#@ load("@ytt:data", "data")
+---
+fullName:
+  clusterName: #@ data.values.cluster
+  location: global
+  name: #@ data.values.namespace
+objectMeta:
+  annotations:
+    vmware.tanzu.mc.template: default
+  description: ""
+  labels: null
+spec:
+  workspaceName: #@ data.values.workspace
+typeMeta:
+  kind: Namespace
+  package: vmware.olympus.v1alpha.cluster.namespace
+  version: v1alpha
+

--- a/config/namespaces/values.yml
+++ b/config/namespaces/values.yml
@@ -1,0 +1,5 @@
+#@data/values
+---
+namespace:
+cluster: 
+workspace:

--- a/values/harbor.yml
+++ b/values/harbor.yml
@@ -53,11 +53,13 @@ ingress:
   ## set to `ncp` if using the NCP (NSX-T Container Plugin) ingress controller
   ##
   controller: contour
+  
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   annotations:
+    kubernetes.io/ingress.class: contour
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: letsencrypt-production
     ingress.kubernetes.io/ssl-redirect: "true"


### PR DESCRIPTION
TL;DR
-----

Document configuring Contour as an ingress controller

Details
-------

This demo presumed Harbor was configured to use an ingress
controller, but when I shifted to creating the cluster with TMC
I didn't included that step in documenting the process. It's
absence became clear when I started again from scratch creating
a cluster strictly follopwing the README.

This change:

* Documents the steps required to add Contour as the ingress
  controller for the demonstration cluster.
* Adds a pod security policy for the Envoy proxy that Contour
  installs as a daemon set. The policy was required since TMC
  enables pod security policies in all clusters that it creates.
  It took the policy definition a rejected pull request
  #projectcontour/contour/pull/1897 to add PSPs to the default
  Contour install.