### PR TITLE
Setup image policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ steps:
    ytt -f config/harbor -f values/harbor.yml --data-value subdomain=$SUBDOMAIN --ignore-unknown-comments > work/harbor.yml 
    helm install -n registry feasible-macaque bitnami/harbor -f secrets/harbor.yml -f work/harbor.yml
    ```
+ 
+9. Create image registry policies for production and staging workspaces
+
+   ```
+   tmc workspace image-policy create -t default-allow-registry --workspace-name $PRODUCTION_WORKSPACE \
+     --name private-registry --registry-domains registry.$SUBDOMAIN
+   tmc workspace image-policy create -t default-allow-registry --workspace-name $STAGING_WORKSPACE \
+     --name trusted-registries --registry-domains registry.$SUBDOMAIN,registry.pivotal.io,gcr.io
+   ```
 
 ## Assumptions
 


### PR DESCRIPTION
TL;DR
-----

Document set up for some simple image policies for staging and
production

Details
-------

Show the `tmc` commands to create image policies for the staging
and production workspaces. They are set up like the other TMC
objects in the demo with the native `tmc` templating capability.

For the staging registry, we show a set of trusted registries to
pull from. In this case, we show a trusted vendor (VMware, via
`registry.pivotal.io`), a more trustworthy public registry
(Google), and our private registry. We include the GCR registry
so that we can use the vulnerable "Kubernetes Up and Running" demo
image at the core of the demo.

For production, we only allow pulling from the private registry.
