### PR TITLE
Pre-configure the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ steps:
    helm install -n registry feasible-macaque bitnami/harbor -f secrets/harbor.yml -f work/harbor.yml
    ```
  
+9. Prepare Harbor by creating a project and configuring a replication
+   endpoint for the Google Container Registry.
+
+   ```
+   export HARBOR_PASSWORD=$(kubectl get -n registry secret feasible-macaque-harbor-core-envvars -o jsonpath='{.data.HARBOR_ADMIN_PASSWORD}' | base64 -d)
+   curl --user "admin:${HARBOR_PASSWORD}" -X POST https://registry.${SUBDOMAIN}/api/v2.0/projects -H "Content-type: application/json" --data @config/project/project.json
+   curl --user "admin:${HARBOR_PASSWORD}" -X POST https://registry.${SUBDOMAIN}/api/v2.0/registries -H "Content-type: application/json" --data @config/replication/gcr.json
+   ```
+
 9. Create image registry policies for production and staging workspaces
 
    ```

--- a/config/project/project.json
+++ b/config/project/project.json
@@ -1,0 +1,11 @@
+{
+  "project_name": "kuard",
+  "metadata": {
+    "auto_scan": "true",
+    "enable_content_trust": "false",
+    "prevent_vul": "true",
+    "public": "true",
+    "reuse_sys_cve_whitelist": "true",
+    "severity": "low"
+  }
+}

--- a/config/replication/gcr.json
+++ b/config/replication/gcr.json
@@ -1,0 +1,17 @@
+{
+    "id": 3,
+    "name": "gcr-no-auth",
+    "description": "",
+    "type": "docker-registry",
+    "url": "https://gcr.io",
+    "token_service_url": "",
+    "credential": {
+      "type": "",
+      "access_key": "",
+      "access_secret": ""
+    },
+    "insecure": false,
+    "status": "healthy",
+    "creation_time": "2020-08-14T17:21:11.034238Z",
+    "update_time": "2020-08-14T17:21:11.034241Z"
+  }

--- a/config/replication/kuard.json
+++ b/config/replication/kuard.json
@@ -1,0 +1,18 @@
+{
+  "name": "next",
+  "description": "",
+  "creator": "admin",
+  "src_registry": {
+    "id": 3
+  },
+  "dest_registry": {
+    "id": 0
+  },
+  "dest_namespace": "kuard",
+  "trigger": {
+    "type": "manual"
+  },
+  "deletion": false,
+  "override": true,
+  "enabled": true
+}


### PR DESCRIPTION
TL;DR
-----

Use the Harbor API to prepare the registry for the demo

Details
-------

The demo depends on two configurations in Harbor. This change
documents how to prepare them beforehand using `curl` and the
Harbor API.

1. A registry connection to `gcr.io` so that we can set up
   replication from GCR to the private registry as part of the
   demo.

2. A destination project for the replicated image. The project is
   pre-configured to scan images on push and to not allow an image
   with open CVEs to be pull.
